### PR TITLE
Pretty labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Version 0.1.3
+
+- Add `MakeWebConsoleWriter`, a more configurable alternative to``MakeConsoleWriter`.
+  `MakeWebConsoleWriter::new()` is a drop-in replacement for the old `MakeConsoleWriter` constructor.
+- Add `MakeWebConsoleWriter::with_pretty_level()` to print a label denoting the level of the logged event.
+
 ## Version 0.1.2
 
 - Change logging method of `Level::TRACE` to `console.debug`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-web"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = [
   "Martin Molzer <WorldSEnder@users.noreply.github.com>",

--- a/README.md
+++ b/README.md
@@ -26,16 +26,15 @@ subscriber that emits messages to the dev-tools console, and events to the [Perf
 configuration can look like
 
 ```rust
-use tracing_web::{MakeConsoleWriter, performance_layer};
+use tracing_web::{MakeWebConsoleWriter, performance_layer};
 use tracing_subscriber::fmt::format::Pretty;
-use tracing_subscriber::fmt::time::UtcTime;
 use tracing_subscriber::prelude::*;
 
 fn main() {
     let fmt_layer = tracing_subscriber::fmt::layer()
         .with_ansi(false) // Only partially supported across browsers
-        .with_timer(UtcTime::rfc_3339()) // see also note below
-        .with_writer(MakeConsoleWriter); // write events to the console
+        .without_time()   // std::time is not available in browsers, see note below
+        .with_writer(MakeWebConsoleWriter::new()); // write events to the console
     let perf_layer = performance_layer()
         .with_details_from_fields(Pretty::default());
 
@@ -48,8 +47,8 @@ fn main() {
 }
 ```
 
-Note: To use `UtcTime` on `web` targets, you need to enable the `wasm-bindgen` feature of the `time`
-crate, for example by adding the following to your `Cargo.toml`.
+Note: You can alternatively use `.with_timer(UtcTime::rfc_3339())` with [`UtcTime`] on `web` targets if you enable
+the `wasm-bindgen` feature of the `time` crate, for example by adding the following to your `Cargo.toml`.
 
 ```toml
 time = { version = "0.3", features = ["wasm-bindgen"] }
@@ -57,6 +56,7 @@ time = { version = "0.3", features = ["wasm-bindgen"] }
 
 [`tracing-subscriber`]: https://crates.io/crates/tracing-subscriber
 [Performance API]: https://developer.mozilla.org/en-US/docs/Web/API/Performance
+[`UtcTime`]: https://docs.rs/tracing-subscriber/0.3.18/tracing_subscriber/fmt/time/struct.UtcTime.html
 
 # License
 

--- a/examples/trace-yew-app/src/main.rs
+++ b/examples/trace-yew-app/src/main.rs
@@ -1,9 +1,6 @@
 use tracing::Span;
 use tracing_subscriber::{
-    fmt::{
-        format::{FmtSpan, Pretty},
-        time::UtcTime,
-    },
+    fmt::format::{FmtSpan, Pretty},
     prelude::*,
 };
 use yew::{function_component, html, Html};
@@ -20,8 +17,9 @@ fn App() -> Html {
 fn main() {
     let fmt_layer = tracing_subscriber::fmt::layer()
         .with_ansi(false)
-        .with_timer(UtcTime::rfc_3339())
-        .with_writer(tracing_web::MakeConsoleWriter)
+        .without_time()
+        .with_writer(tracing_web::MakeWebConsoleWriter::new().with_pretty_level())
+        .with_level(false)
         .with_span_events(FmtSpan::ACTIVE);
     let perf_layer = tracing_web::performance_layer().with_details_from_fields(Pretty::default());
 
@@ -31,8 +29,12 @@ fn main() {
         .init();
 
     tracing::debug_span!("top-level", i = 5).in_scope(|| {
+        tracing::trace!("This is a trace message.");
         let message = "debug message";
         tracing::debug!(msg = ?message, "Hello, world!");
+        tracing::warn!("This is a sample warning.");
+        tracing::error!("This shows up as an error.");
+        tracing::info!("This contains an informational message.");
         Span::current().record("i", 7);
     });
     yew::Renderer::<App>::new().render();

--- a/src/console_writer.rs
+++ b/src/console_writer.rs
@@ -5,6 +5,29 @@ use tracing_subscriber::fmt::MakeWriter;
 use wasm_bindgen::JsValue;
 use web_sys::console;
 
+/// **Discouraged** A [`MakeWriter`] emitting the written text to the [`console`].
+///
+/// The used log method is sensitive to the level the event is emitted with.
+///
+/// | Level     | Method           |
+/// |-----------|------------------|
+/// | TRACE     | console.debug    |
+/// | DEBUG     | console.debug    |
+/// | INFO      | console.info     |
+/// | WARN      | console.warn     |
+/// | ERROR     | console.error    |
+/// | other     | console.log      |
+///
+/// ### Note
+///
+/// Since version `0.1.3`, you should prefer the alternative, more powerful [MakeWebConsoleWriter].
+// For now, I have decided against deprecating this. While I do intend to deprecate or even remove it in 0.2, a warning is probably too picky on downstream developers.
+// #[deprecated(
+//     since = "0.1.3",
+//     note = "use `MakeWebConsoleWriter` instead, which provides a more future proof API"
+// )]
+pub struct MakeConsoleWriter;
+
 /// A [`MakeWriter`] emitting the written text to the [`console`].
 ///
 /// The used log method is sensitive to the level the event is emitted with.
@@ -17,12 +40,41 @@ use web_sys::console;
 /// | WARN      | console.warn     |
 /// | ERROR     | console.error    |
 /// | other     | console.log      |
-pub struct MakeConsoleWriter;
+pub struct MakeWebConsoleWriter {
+    use_pretty_label: bool,
+}
 
-/// Concrete [`std::io::Write`] implementation returned from [`MakeConsoleWriter`].
+impl Default for MakeWebConsoleWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MakeWebConsoleWriter {
+    /// Create a default console writer, i.e. no level annotation is shown when logging a message.
+    pub fn new() -> Self {
+        Self {
+            use_pretty_label: false,
+        }
+    }
+    /// Enables an additional label for the log level to be shown.
+    ///
+    /// It is recommended that you also use [`Layer::with_level(false)`] if you use this option, to avoid the event level being shown twice.
+    ///
+    /// [`Layer::with_level(false)`]: tracing_subscriber::fmt::Layer::with_level
+    pub fn with_pretty_level(mut self) -> Self {
+        self.use_pretty_label = true;
+        self
+    }
+}
+
+type LogDispatcher = fn(Level, &str);
+
+/// Concrete [`std::io::Write`] implementation returned by [`MakeConsoleWriter`] and [`MakeWebConsoleWriter`].
 pub struct ConsoleWriter {
     buffer: Vec<u8>,
-    log: fn(&str),
+    level: Level,
+    log: LogDispatcher,
 }
 
 impl Write for ConsoleWriter {
@@ -42,52 +94,143 @@ impl Drop for ConsoleWriter {
         //  just to re-encode as utf-16 when crossing wasm-bindgen boundaries
         // we could use TextDecoder directly to produce a
         let message = String::from_utf8_lossy(&self.buffer);
-        (self.log)(message.as_ref())
+        (self.log)(self.level, message.as_ref())
     }
 }
 
-fn console_debug(msg: &str) {
-    console::debug_1(&JsValue::from(msg))
-}
-fn console_info(msg: &str) {
-    console::info_1(&JsValue::from(msg))
-}
-fn console_warn(msg: &str) {
-    console::warn_1(&JsValue::from(msg))
-}
-fn console_error(msg: &str) {
-    console::error_1(&JsValue::from(msg))
-}
-fn console_log(msg: &str) {
-    console::log_1(&JsValue::from(msg))
+trait LogImpl {
+    fn log_simple(level: Level, msg: &str);
+    fn log_pretty(level: Level, msg: &str);
 }
 
+macro_rules! make_log_impl {
+    ($T:ident {
+        simple: $s:expr,
+        pretty: {
+            log: $p:expr, fmt: $f:expr, label_style: $l:expr $(,)?
+        } $(,)?
+    }) => {
+        struct $T;
+        impl LogImpl for $T {
+            #[inline(always)]
+            fn log_simple(_level: Level, msg: &str) {
+                $s(&JsValue::from(msg));
+            }
+            #[inline(always)]
+            fn log_pretty(_level: Level, msg: &str) {
+                let fmt = JsValue::from(wasm_bindgen::intern($f));
+                let label_style = JsValue::from(wasm_bindgen::intern($l));
+                let msg_style =
+                    JsValue::from(wasm_bindgen::intern("background: inherit; color: inherit;"));
+                $p(&fmt, &label_style, &msg_style, &JsValue::from(msg));
+            }
+        }
+    };
+}
+
+// Even though console.trace exists and generates stack traces, it logs with level: info, so leads to verbose logs, so log with debug
+make_log_impl!(LogLevelTrace { simple: console::debug_1, pretty: { log: console::debug_4, fmt: "%cTRACE%c %s", label_style: "color: white; font-weight: bold; padding: 0 3px; background: #75507B;" } });
+make_log_impl!(LogLevelDebug { simple: console::debug_1, pretty: { log: console::debug_4, fmt: "%cDEBUG%c %s", label_style: "color: white; font-weight: bold; padding: 0 3px; background: #3465A4;" } });
+make_log_impl!(LogLevelInfo  { simple: console::info_1,  pretty: { log: console::info_4,  fmt: "%cINFO%c %s", label_style: "color: white; font-weight: bold; padding: 0 3px; background: #4E9A06;" } });
+make_log_impl!(LogLevelWarn  { simple: console::warn_1,  pretty: { log: console::warn_4,  fmt: "%cWARN%c %s", label_style: "color: white; font-weight: bold; padding: 0 3px; background: #C4A000;" } });
+make_log_impl!(LogLevelError { simple: console::error_1, pretty: { log: console::error_4, fmt: "%cERROR%c %s", label_style: "color: white; font-weight: bold; padding: 0 3px; background: #CC0000;" } });
+struct LogLevelFallback;
+impl LogImpl for LogLevelFallback {
+    #[inline(always)]
+    fn log_simple(_level: Level, msg: &str) {
+        console::log_1(&JsValue::from(msg))
+    }
+
+    #[inline(always)]
+    fn log_pretty(level: Level, msg: &str) {
+        let fmt = JsValue::from(wasm_bindgen::intern("%c%s%c %s"));
+        let label_level = JsValue::from(format!("{}", level));
+        let label_style = JsValue::from(wasm_bindgen::intern(""));
+        let msg_style = JsValue::from(wasm_bindgen::intern(""));
+        let msg = JsValue::from(msg);
+        console::log_5(&fmt, &label_style, &label_level, &msg_style, &msg)
+    }
+}
+
+trait LogImplStyle {
+    fn get_dispatch<L: LogImpl>(&self) -> LogDispatcher;
+}
+struct SimpleStyle;
+impl LogImplStyle for SimpleStyle {
+    #[inline(always)]
+    fn get_dispatch<L: LogImpl>(&self) -> LogDispatcher {
+        L::log_simple
+    }
+}
+struct PrettyStyle;
+impl LogImplStyle for PrettyStyle {
+    #[inline(always)]
+    fn get_dispatch<L: LogImpl>(&self) -> LogDispatcher {
+        L::log_pretty
+    }
+}
+
+fn select_dispatcher(style: impl LogImplStyle, level: Level) -> LogDispatcher {
+    if level == Level::TRACE {
+        style.get_dispatch::<LogLevelTrace>()
+    } else if level == Level::DEBUG {
+        style.get_dispatch::<LogLevelDebug>()
+    } else if level == Level::INFO {
+        style.get_dispatch::<LogLevelInfo>()
+    } else if level == Level::WARN {
+        style.get_dispatch::<LogLevelWarn>()
+    } else if level == Level::ERROR {
+        style.get_dispatch::<LogLevelError>()
+    } else {
+        style.get_dispatch::<LogLevelFallback>()
+    }
+}
+
+impl MakeConsoleWriter {
+    // "upgrade" to the non-deprecated version of MakeConsoleWriter, mainly to unify code paths.
+    fn upgrade(&self) -> MakeWebConsoleWriter {
+        MakeWebConsoleWriter {
+            use_pretty_label: false,
+        }
+    }
+}
 impl<'a> MakeWriter<'a> for MakeConsoleWriter {
+    type Writer = ConsoleWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.upgrade().make_writer()
+    }
+
+    fn make_writer_for(&'a self, meta: &tracing_core::Metadata<'_>) -> Self::Writer {
+        self.upgrade().make_writer_for(meta)
+    }
+}
+
+impl<'a> MakeWriter<'a> for MakeWebConsoleWriter {
     type Writer = ConsoleWriter;
 
     fn make_writer(&'a self) -> Self::Writer {
         ConsoleWriter {
             buffer: vec![],
-            log: console_log,
+            level: Level::TRACE, // if no level is known, assume the most detailed
+            log: if self.use_pretty_label {
+                PrettyStyle.get_dispatch::<LogLevelFallback>()
+            } else {
+                SimpleStyle.get_dispatch::<LogLevelFallback>()
+            },
         }
     }
 
     fn make_writer_for(&'a self, meta: &tracing_core::Metadata<'_>) -> Self::Writer {
-        let level = meta.level();
-        let log_fn = if *level == Level::TRACE || *level == Level::DEBUG {
-            // Even though console.trace exists and generates stack traces, it logs with level: info, so leads to verbose logs
-            console_debug
-        } else if *level == Level::INFO {
-            console_info
-        } else if *level == Level::WARN {
-            console_warn
-        } else if *level == Level::ERROR {
-            console_error
+        let level = *meta.level();
+        let log_fn = if self.use_pretty_label {
+            select_dispatcher(PrettyStyle, level)
         } else {
-            console_log
+            select_dispatcher(SimpleStyle, level)
         };
         ConsoleWriter {
             buffer: vec![],
+            level,
             log: log_fn,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,15 +3,15 @@
 //! # Example usage
 //!
 //! ```rust, no_run
-//! use tracing_web::{MakeConsoleWriter, performance_layer};
+//! use tracing_web::{MakeWebConsoleWriter, performance_layer};
 //! use tracing_subscriber::fmt::format::Pretty;
 //! use tracing_subscriber::fmt::time::UtcTime;
 //! use tracing_subscriber::prelude::*;
 //!
 //! let fmt_layer = tracing_subscriber::fmt::layer()
 //!     .with_ansi(false) // Only partially supported across browsers
-//!     .with_timer(UtcTime::rfc_3339()) // std::time is not available in browsers
-//!     .with_writer(MakeConsoleWriter); // write events to the console
+//!     .without_time()   // std::time is not available in browsers
+//!     .with_writer(MakeWebConsoleWriter::new()); // write events to the console
 //! let perf_layer = performance_layer().with_details_from_fields(Pretty::default());
 //!
 //! tracing_subscriber::registry()
@@ -32,4 +32,4 @@ pub use performance_layer::{
     performance_layer, FormatSpan, FormatSpanFromFields, PerformanceEventsLayer,
 };
 mod console_writer;
-pub use console_writer::{ConsoleWriter, MakeConsoleWriter};
+pub use console_writer::{ConsoleWriter, MakeConsoleWriter, MakeWebConsoleWriter};


### PR DESCRIPTION
Add an alternative `MakeWebConsoleWriter` that implements configurable options to replace `MakeConsoleWriter` at some point in the future.

Fixes #4

Example use case would be

```diff,rust
-    .with_writer(tracing_web::MakeConsoleWriter)
+    .with_writer(tracing_web::MakeWebConsoleWriter::new().with_pretty_level())
```

It is recommended to also disable levels on the format layer of `tracing_subscriber` in this case

```diff,rust
+    .with_level(false)
```

See also the example for a use case https://github.com/WorldSEnder/tracing-web/blob/bd4b6b89bb22ccecc2438f862f43664cd7940917/examples/trace-yew-app/src/main.rs#L18-L23